### PR TITLE
Add argparse import for CLI

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from pathlib import Path
 
@@ -7,6 +6,7 @@ from datasets.xml_loader import load_dataset
 from inference.predictor import Predictor
 from metrics.evaluator import Evaluator
 from log_setup import setup_logging
+import argparse
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- import `argparse` after other modules in `src/cli.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e54f2a9b88321a8e3e3017095a27c