### PR TITLE
Add per-folder confusion matrix output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 
 2，可供选择是否需要保存预测后带有标注框的图片，放入到指定目录下。文件夹命名与结构和测试数据集相同
 
-3，创建GUI界面以选择参数
+3，创建GUI界面以选择参数，可浏览 ``models`` 目录下的 ``.pt`` 或 ``.onnx`` 模型，
+   并选择数据集根目录
 
-4，使用进度条
+4，使用进度条显示推理进度
 
 ```python
 YOLO-Model-Test/
@@ -68,7 +69,7 @@ YOLO-Model-Test/
 - **数据集处理**：`dataset/xml_loader.py` 负责加载图片与标注，`dataset_stats.py` 计算类别分布、标注框尺寸等统计信息。
 - **推理与评估**：`predictor.py` 使用指定模型权重对图片推理。`metrics/evaluator.py` 计算多种指标并生成混淆矩阵；必要时可在 `metrics/confusion.py` 实现可视化。
 - **模型管理**：`model_manager/loader.py` 方便在多个模型间切换或记录版本信息。
-- **GUI**：`ui/gui.py` 提供参数选择界面和进度条，对 `predictor` 与 `evaluator` 封装。
+- **GUI**：`ui/gui.py` 提供参数选择界面和进度条，可浏览模型文件和数据集目录，对 `predictor` 与 `evaluator` 封装。
 - **单元测试与 CI**：`tests/` 编写覆盖数据加载、推理、评估等功能的测试脚本，可与持续集成工具（如 GitHub Actions）结合，保证更新的稳定性。
 
 针对“如何开始”：

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ YOLO-Model-Test/
 **模块说明**
 
 - **CLI 与配置管理**：`cli.py` 结合 `config.py` 读取 `configs/default.yaml`，支持在命令行执行推理、输出指标或批量保存预测图像。
+- **路径解析**：配置文件中使用的相对路径均以项目根目录为基准，可在任意目录调用脚本。
+- **混淆矩阵脚本**：`confusion_cli.py` 会为数据集下的每个子文件夹及整体数据生成混淆矩阵和概率矩阵，并将图像保存到 `output/数据集N/子文件夹` 结构中，便于查看分类效果。
 - **日志与报告**：`log_setup.py` 初始化日志系统，并在测试结束后导出 Markdown/HTML 报告，可记录每个模型及数据集的表现。
 - **数据集处理**：`dataset/xml_loader.py` 负责加载图片与标注，`dataset_stats.py` 计算类别分布、标注框尺寸等统计信息。
 - **推理与评估**：`predictor.py` 使用指定模型权重对图片推理。`metrics/evaluator.py` 计算多种指标并生成混淆矩阵；必要时可在 `metrics/confusion.py` 实现可视化。
@@ -78,7 +80,9 @@ YOLO-Model-Test/
 3. **构建推理和评估流程**  
    - 在 `src/inference/predictor.py` 调用 YOLOv8 模型，对输入图片进行推理。  
    - 在 `src/metrics/evaluator.py` 计算混淆矩阵、Precision/Recall/F1、mAP 等指标，并按 README 所述生成混淆概率矩阵等可视化结果。
-4. **提供命令行或 GUI 入口**  
+4. **提供命令行或 GUI 入口**
    `src/cli.py` 或 `src/ui/gui.py` 可以作为统一入口，允许用户选择模型、数据集和输出目录。根据需要还能加入日志功能（`src/log_setup.py`）。
-5. **补充单元测试**  
+5. **补充单元测试**
    仿照 `tests/` 目录的规划，为数据加载、模型推理和评估模块编写基础测试，确保后续修改不会破坏现有功能。
+6. **生成混淆矩阵**
+   使用 `python src/confusion_cli.py --model models/best.pt --data test_data --output output` 运行，结果会写入 `output/test_data1/`（下次运行为 `test_data2/` 等），其中包含每个子文件夹和整体数据的混淆矩阵及概率矩阵图像。

--- a/src/config.py
+++ b/src/config.py
@@ -59,11 +59,19 @@ class Config:
 
     @classmethod
     def from_file(cls, path: str | None = None) -> "Config":
+        """Load configuration and resolve relative paths."""
         if path is None:
             root = os.path.dirname(os.path.dirname(__file__))
             path = os.path.join(root, "configs", "default.yaml")
         data = load_config(path)
-        return cls(**data)
+        cfg = cls(**data)
+
+        repo_root = os.path.dirname(os.path.dirname(__file__))
+        for key in ("model_path", "data_dir", "output_dir"):
+            value = getattr(cfg, key)
+            if not os.path.isabs(value):
+                setattr(cfg, key, os.path.join(repo_root, value))
+        return cfg
 
     def as_dict(self) -> Dict[str, Any]:
         return self.__dict__.copy()

--- a/src/confusion_cli.py
+++ b/src/confusion_cli.py
@@ -1,0 +1,125 @@
+import argparse
+import logging
+from pathlib import Path
+
+from config import Config
+from datasets.xml_loader import load_dataset
+from inference.predictor import Predictor
+from metrics.evaluator import Evaluator
+from metrics.confusion import plot_confusion_matrix
+from log_setup import setup_logging
+
+try:
+    from tqdm import tqdm  # type: ignore
+except Exception:  # pragma: no cover - optional dependency may not be available
+    tqdm = None  # type: ignore
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run evaluation and save confusion matrix")
+    parser.add_argument("--config", help="Path to config file", default=None)
+    parser.add_argument("--model", help="Model weights", default=None)
+    parser.add_argument("--data", help="Dataset directory", default=None)
+    parser.add_argument("--output", help="Output directory", default=None)
+    parser.add_argument("--no-save", action="store_true", help="Do not save prediction txt")
+    parser.add_argument("--log-dir", help="Directory for logs", default="logs")
+    parser.add_argument("--progress", action="store_true", help="Show progress bar")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    cfg = Config.from_file(args.config)
+    if args.model:
+        cfg.model_path = args.model
+    if args.data:
+        cfg.data_dir = args.data
+    if args.output:
+        cfg.output_dir = args.output
+    if args.no_save:
+        cfg.save_predictions = False
+
+    out_root = Path(cfg.output_dir)
+    data_name = Path(cfg.data_dir).name
+    idx = 1
+    while (out_root / f"{data_name}{idx}").exists():
+        idx += 1
+    run_dir = out_root / f"{data_name}{idx}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    log_file = run_dir / "run.log"
+    setup_logging(str(log_file))
+
+    logging.info("Loading dataset from %s", cfg.data_dir)
+    annotations = load_dataset(cfg.data_dir)
+    predictor = Predictor(cfg.model_path, cfg.confidence_threshold)
+    predictions = {}
+
+    iterable = annotations
+    if args.progress:
+        if tqdm is not None:
+            iterable = tqdm(annotations, desc="Predicting", unit="img")
+        else:
+            total = len(annotations)
+            def _simple_progress(items: list) -> "list":
+                for idx, item in enumerate(items, 1):
+                    print(f"{idx}/{total}", end="\r")
+                    yield item
+                print()
+            iterable = _simple_progress(annotations)
+
+    for ann in iterable:
+        boxes = predictor.predict(ann.image_path)
+        predictions[ann.image_path] = boxes
+
+    evaluator = Evaluator(cfg.iou_threshold)
+
+    def save_result(name: str, anns: list) -> None:
+        preds = {a.image_path: predictions[a.image_path] for a in anns}
+        res = evaluator.evaluate(anns, preds)
+        logging.info(
+            "%s - Precision: %.3f Recall: %.3f F1: %.3f mAP50: %.3f",
+            name,
+            res.precision,
+            res.recall,
+            res.f1,
+            res.map50,
+        )
+        labels = ["positive", "negative"]
+        sub_dir = run_dir / name if name != "overall" else run_dir
+        sub_dir.mkdir(parents=True, exist_ok=True)
+        cm_path = sub_dir / "confusion_matrix.png"
+        cmp_path = sub_dir / "confusion_probability.png"
+        try:
+            plot_confusion_matrix(res.confusion_matrix, labels, False, str(cm_path))
+            plot_confusion_matrix(res.confusion_prob, labels, True, str(cmp_path))
+        except Exception as exc:
+            logging.error("Failed to plot confusion matrix: %s", exc)
+
+    # overall
+    save_result("overall", annotations)
+
+    # per folder
+    groups: dict[str, list] = {}
+    root = Path(cfg.data_dir)
+    for ann in annotations:
+        rel = Path(ann.image_path).relative_to(root)
+        grp = rel.parts[0] if len(rel.parts) > 1 else root.name
+        groups.setdefault(grp, []).append(ann)
+
+    for name, anns in groups.items():
+        save_result(name, anns)
+
+    if cfg.save_predictions:
+        pred_file = run_dir / "predictions.txt"
+        with pred_file.open("w", encoding="utf-8") as fh:
+            for img, boxes in predictions.items():
+                b_str = " ".join(
+                    f"{b.label},{b.xmin},{b.ymin},{b.xmax},{b.ymax}" for b in boxes
+                )
+                fh.write(f"{img} {b_str}\n")
+        logging.info("Predictions saved to %s", pred_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/log_setup.py
+++ b/src/log_setup.py
@@ -3,14 +3,24 @@ from datetime import datetime
 from pathlib import Path
 
 
-def setup_logging(log_dir: str = "logs") -> logging.Logger:
-    """Initialize logging to file and console."""
-    Path(log_dir).mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    log_file = Path(log_dir) / f"log_{timestamp}.txt"
+def setup_logging(path: str = "logs") -> logging.Logger:
+    """Initialize logging to file and console.
+
+    ``path`` can be either a directory or a full log file path. When a
+    directory is provided, a timestamped file will be created inside it.
+    """
+
+    log_path = Path(path)
+    if log_path.suffix:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        log_path.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        log_path = log_path / f"log_{timestamp}.txt"
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(message)s",
-        handlers=[logging.FileHandler(log_file), logging.StreamHandler()],
+        handlers=[logging.FileHandler(log_path), logging.StreamHandler()],
     )
     return logging.getLogger(__name__)

--- a/src/ui/gui.py
+++ b/src/ui/gui.py
@@ -1,12 +1,104 @@
-"""Simple Tkinter GUI for launching model evaluation."""
+"""Simple Tkinter GUI for launching model evaluation with progress."""
 
 from __future__ import annotations
 
-import subprocess
+import logging
 import sys
+import threading
 from pathlib import Path
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import filedialog, messagebox, ttk
+
+from config import Config
+from datasets.xml_loader import load_dataset, Annotation
+from inference.predictor import Predictor
+from metrics.evaluator import Evaluator
+from metrics.confusion import plot_confusion_matrix
+from log_setup import setup_logging
+
+
+def run_evaluation(
+    model_path: str,
+    data_dir: str,
+    output_dir: str,
+    save_predictions: bool,
+    progress_cb: callable | None = None,
+) -> None:
+    """Run evaluation, reporting progress via ``progress_cb``."""
+    cfg = Config.from_file(None)
+    cfg.model_path = model_path
+    cfg.data_dir = data_dir
+    cfg.output_dir = output_dir
+    cfg.save_predictions = save_predictions
+
+    out_root = Path(cfg.output_dir)
+    data_name = Path(cfg.data_dir).name
+    idx = 1
+    while (out_root / f"{data_name}{idx}").exists():
+        idx += 1
+    run_dir = out_root / f"{data_name}{idx}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    log_file = run_dir / "run.log"
+    setup_logging(str(log_file))
+
+    logging.info("Loading dataset from %s", cfg.data_dir)
+    annotations = load_dataset(cfg.data_dir)
+    predictor = Predictor(cfg.model_path, cfg.confidence_threshold)
+
+    predictions: dict[str, list] = {}
+    total = len(annotations)
+    for i, ann in enumerate(annotations, 1):
+        boxes = predictor.predict(ann.image_path)
+        predictions[ann.image_path] = boxes
+        if progress_cb:
+            progress_cb(i, total)
+
+    evaluator = Evaluator(cfg.iou_threshold)
+
+    def save_result(name: str, anns: list[Annotation]) -> None:
+        preds = {a.image_path: predictions[a.image_path] for a in anns}
+        res = evaluator.evaluate(anns, preds)
+        logging.info(
+            "%s - Precision: %.3f Recall: %.3f F1: %.3f mAP50: %.3f",
+            name,
+            res.precision,
+            res.recall,
+            res.f1,
+            res.map50,
+        )
+        labels = ["positive", "negative"]
+        sub_dir = run_dir / name if name != "overall" else run_dir
+        sub_dir.mkdir(parents=True, exist_ok=True)
+        cm_path = sub_dir / "confusion_matrix.png"
+        cmp_path = sub_dir / "confusion_probability.png"
+        try:
+            plot_confusion_matrix(res.confusion_matrix, labels, False, str(cm_path))
+            plot_confusion_matrix(res.confusion_prob, labels, True, str(cmp_path))
+        except Exception as exc:  # pragma: no cover - matplotlib optional
+            logging.error("Failed to plot confusion matrix: %s", exc)
+
+    save_result("overall", annotations)
+
+    groups: dict[str, list[Annotation]] = {}
+    root_dir = Path(cfg.data_dir)
+    for ann in annotations:
+        rel = Path(ann.image_path).relative_to(root_dir)
+        grp = rel.parts[0] if len(rel.parts) > 1 else root_dir.name
+        groups.setdefault(grp, []).append(ann)
+
+    for name, anns in groups.items():
+        save_result(name, anns)
+
+    if cfg.save_predictions:
+        pred_file = run_dir / "predictions.txt"
+        with pred_file.open("w", encoding="utf-8") as fh:
+            for img, boxes in predictions.items():
+                b_str = " ".join(
+                    f"{b.label},{b.xmin},{b.ymin},{b.xmax},{b.ymax}" for b in boxes
+                )
+                fh.write(f"{img} {b_str}\n")
+        logging.info("Predictions saved to %s", pred_file)
 
 
 def launch() -> None:
@@ -17,35 +109,52 @@ def launch() -> None:
     tk.Label(root, text="Model path:").grid(row=0, column=0, sticky="e")
     model_var = tk.StringVar(value="models/best.pt")
     tk.Entry(root, textvariable=model_var, width=40).grid(row=0, column=1)
+    tk.Button(root, text="Browse", command=lambda: model_var.set(
+        filedialog.askopenfilename(initialdir="models", filetypes=[("Model", "*.pt *.onnx"), ("All", "*.*")])
+    )).grid(row=0, column=2)
 
     tk.Label(root, text="Data directory:").grid(row=1, column=0, sticky="e")
     data_var = tk.StringVar(value="test_data")
     tk.Entry(root, textvariable=data_var, width=40).grid(row=1, column=1)
+    tk.Button(root, text="Browse", command=lambda: data_var.set(
+        filedialog.askdirectory(initialdir="test_data")
+    )).grid(row=1, column=2)
 
     tk.Label(root, text="Output directory:").grid(row=2, column=0, sticky="e")
     out_var = tk.StringVar(value="output")
     tk.Entry(root, textvariable=out_var, width=40).grid(row=2, column=1)
+    tk.Button(root, text="Browse", command=lambda: out_var.set(
+        filedialog.askdirectory(initialdir="output")
+    )).grid(row=2, column=2)
 
     save_var = tk.BooleanVar(value=False)
-    tk.Checkbutton(root, text="Save predictions", variable=save_var).grid(row=3, columnspan=2)
+    tk.Checkbutton(root, text="Save predictions", variable=save_var).grid(row=3, columnspan=3)
 
-    def run_cli() -> None:
-        cmd = [
-            sys.executable,
-            str(Path(__file__).resolve().parents[1] / "cli.py"),
-            "--model",
-            model_var.get(),
-            "--data",
-            data_var.get(),
-            "--output",
-            out_var.get(),
-        ]
-        if not save_var.get():
-            cmd.append("--no-save")
-        subprocess.Popen(cmd)
-        messagebox.showinfo("YOLO Model Test", "Started: {}".format(" ".join(cmd)))
+    progress = ttk.Progressbar(root, orient="horizontal", length=300, mode="determinate")
+    progress.grid(row=4, columnspan=3, pady=5)
 
-    tk.Button(root, text="Run", command=run_cli).grid(row=4, columnspan=2, pady=5)
+    def update_progress(current: int, total: int) -> None:
+        progress["maximum"] = total
+        progress["value"] = current
+        root.update_idletasks()
+
+    def run() -> None:
+        def _worker() -> None:
+            try:
+                run_evaluation(
+                    model_var.get(),
+                    data_var.get(),
+                    out_var.get(),
+                    save_var.get(),
+                    update_progress,
+                )
+                messagebox.showinfo("YOLO Model Test", "Evaluation complete")
+            except Exception as exc:  # pragma: no cover - UI errors
+                messagebox.showerror("YOLO Model Test", str(exc))
+
+        threading.Thread(target=_worker, daemon=True).start()
+
+    tk.Button(root, text="Run", command=run).grid(row=5, columnspan=3, pady=5)
     root.mainloop()
 
 

--- a/tests/test_confusion_cli.py
+++ b/tests/test_confusion_cli.py
@@ -1,0 +1,24 @@
+import subprocess
+import sys
+from pathlib import Path
+import importlib
+import pytest
+
+
+@pytest.mark.skipif(importlib.util.find_spec('matplotlib') is None, reason='requires matplotlib')
+def test_confusion_cli(tmp_path: Path) -> None:
+    out_root = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        str(Path('src') / 'confusion_cli.py'),
+        '--model', 'models/best.pt',
+        '--data', 'test_data',
+        '--output', str(out_root),
+    ]
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    assert result.returncode == 0
+    run_dir = out_root / 'test_data1'
+    assert (run_dir / 'confusion_matrix.png').exists()
+    assert (run_dir / 'test1' / 'confusion_matrix.png').exists()
+    assert (run_dir / 'test2' / 'confusion_matrix.png').exists()
+    assert (run_dir / 'run.log').exists()

--- a/tests/test_gui_run.py
+++ b/tests/test_gui_run.py
@@ -1,0 +1,17 @@
+import importlib
+from pathlib import Path
+
+import pytest
+
+from src.ui.gui import run_evaluation
+
+
+@pytest.mark.skipif(importlib.util.find_spec('matplotlib') is None, reason='requires matplotlib')
+def test_run_evaluation(tmp_path: Path) -> None:
+    out_root = tmp_path / "out"
+    run_evaluation('models/best.pt', 'test_data', str(out_root), False)
+    run_dir = out_root / 'test_data1'
+    assert (run_dir / 'confusion_matrix.png').exists()
+    assert (run_dir / 'test1' / 'confusion_matrix.png').exists()
+    assert (run_dir / 'run.log').exists()
+


### PR DESCRIPTION
## Summary
- compute confusion matrices for each subfolder and overall in `confusion_cli`
- allow `setup_logging` to accept a log file path
- store confusion CLI results under numbered run directories and write a single log file per run
- document behaviour in README
- test new CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686353f71b1483219e4ad38e21b9282d